### PR TITLE
Check for rules property before accessing it

### DIFF
--- a/src/BackgroundUtils.js
+++ b/src/BackgroundUtils.js
@@ -8,7 +8,9 @@ const getStyle = className => {
   const styleSheets = typeof window !== `undefined` ?
       window.document.styleSheets : []
   for (let i = 0; i < styleSheets.length; i++) {
-    const classes = styleSheets[i].rules || styleSheets[i].cssRules
+    const classes =
+      (styleSheets[i].hasOwnProperty('rules') && styleSheets[i].rules) ||
+      (styleSheets[i].hasOwnProperty('cssRules') && styleSheets[i].cssRules)
     if (!classes)
       continue;
     for (let x = 0; x < classes.length; x++) {
@@ -123,5 +125,3 @@ const getBackgroundStyles = className => {
 }
 
 export default getBackgroundStyles
-
-


### PR DESCRIPTION
This avoids Chrome (as of 64, I think?) throwing a security error:

`Uncaught DOMException: Failed to read the 'rules' property from 'CSSStyleSheet': Cannot access rules`

This happens on remotely loaded CSS (in my case, injected by a third-party chat widget). It ends up halting the rendering of the page in Gatsby.