### PR TITLE
Truthy check imageRef

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@ class BackgroundImage extends React.Component {
           nextImage = ``
       if (image.tracedSVG) nextImage = `"${ image.tracedSVG }"`
       if (image.base64 && !image.tracedSVG) nextImage = image.base64
-      if (this.state.isVisible) nextImage = this.imageRef.currentSrc || image.src
+      if (this.state.isVisible) nextImage = (this.imageRef && this.imageRef.currentSrc) || image.src
       const noBase64 = !image.base64
 
       // Switch bgImage & nextImage and opacity accordingly.
@@ -244,7 +244,7 @@ class BackgroundImage extends React.Component {
           nextImage = null
       if (image.tracedSVG) nextImage = `"${ image.tracedSVG }"`
       if (image.base64 && !image.tracedSVG) nextImage = image.base64
-      if (this.state.isVisible) nextImage = this.imageRef.currentSrc || image.src
+      if (this.state.isVisible) nextImage = (this.imageRef && this.imageRef.currentSrc) || image.src
       const noBase64 = !!image.base64
 
       // Switch bgImage & nextImage and opacity accordingly.


### PR DESCRIPTION
hey @timhagn

I've been using gatsby-background-image on a recent gatsby + contentful project, works great. 

I was running into one issue when doing static gatsby build when using the 'critical' prop on background image object - `TypeError: Cannot read property 'currentSrc' of null` as imageRef was null. I added these little checks to take care of those conditionals.

Cheers and thanks for your great work