### PR TITLE
Use quotes in url returned from getUrlString

### DIFF
--- a/packages/gatsby-background-image/src/ImageUtils.js
+++ b/packages/gatsby-background-image/src/ImageUtils.js
@@ -463,14 +463,14 @@ export const getUrlString = ({
       const currentReturnString =
         tracedSVG && currentString ? `"${currentString}"` : currentString
       return addUrl && currentString
-        ? `url(${currentReturnString})`
+        ? `url('${currentReturnString}')`
         : currentReturnString
     })
     return returnArray ? stringArray : filteredJoin(stringArray)
   } else {
     const returnString =
       tracedSVG && imageString ? `"${imageString}"` : imageString
-    return imageString ? (addUrl ? `url(${returnString})` : returnString) : ``
+    return imageString ? (addUrl ? `url('${returnString}')` : returnString) : ``
   }
 }
 


### PR DESCRIPTION
## Description

This PR makes getUrlString return a ```url()``` with quotes e.g. ```url('someurl')```

The reason i'm posting this PR is that i'm using storyblok and the package gatsby-storyblok-image which uses storybloks cdn filters in the url e.g. ```filters:quality:(100)``` which makes the images fail to load without quotes.
