### PR TITLE
Fixed link for multiple stacked background images

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It has all the advantages of [gatsby-image](https://github.com/gatsbyjs/gatsby/t
 including the "blur-up" technique or a "[traced placeholder](https://github.com/gatsbyjs/gatsby/issues/2435)"
 SVG to show a preview of the image while it loads,  
 **plus** being usable as a container (no more hacks with extra wrappers),  
-**plus** being able to work with [multiple stacked background images](#how-to-use-with-multiple-images).
+**plus** being able to work with [multiple stacked background images](https://github.com/timhagn/gatsby-background-image/tree/master/packages/gatsby-background-image#how-to-use-with-multiple-images).
 
 All the glamour (and speed) of `gatsby-image` for your Background Images!
 


### PR DESCRIPTION
I noticed that when  I clicked on the link it didn't take you anywhere. 🤔 
Probably because it's now split int `-background-image` and `-background-image-es5` 
I just updated the link for the regular version section on multiple images section.

## Description

Just changed the link for multiple stacked background images

## Related Issues

Not sure 🤷‍♂ 
