### PR TITLE
bug: Fixed a lack of a re-render when images in a stack change order

### DIFF
--- a/packages/gatsby-background-image/src/ImageUtils.js
+++ b/packages/gatsby-background-image/src/ImageUtils.js
@@ -546,7 +546,7 @@ export const imageArrayPropsChanged = (props, prevProps) => {
     if (isPropsFluidArray && isPrevPropsFluidArray) {
       if (props.fluid.length === prevProps.fluid.length) {
         // Check for individual image or CSS string changes.
-        return props.fluid.every(
+        return props.fluid.some(
           (image, index) => image.src !== prevProps.fluid[index].src
         )
       }
@@ -554,7 +554,7 @@ export const imageArrayPropsChanged = (props, prevProps) => {
     } else if (isPropsFixedArray && isPrevPropsFixedArray) {
       if (props.fixed.length === prevProps.fixed.length) {
         // Check for individual image or CSS string changes.
-        return props.fixed.every(
+        return props.fixed.some(
           (image, index) => image.src !== prevProps.fixed[index].src
         )
       }


### PR DESCRIPTION
## Description

Previous to this change, when changing the order of a stack of images, there would not be a re-render. 

For example if stacking several images in order to load them all on initial page load, then switching between them by mutating the order - previously this wouldn't work.

This change correctly re-renders in this instance.