### PR TITLE
Fix Tag propType to accept string and functions

### DIFF
--- a/packages/gatsby-background-image/src/index.js
+++ b/packages/gatsby-background-image/src/index.js
@@ -433,7 +433,7 @@ BackgroundImage.propTypes = {
   onLoad: PropTypes.func,
   onError: PropTypes.func,
   onStartLoad: PropTypes.func,
-  Tag: PropTypes.string,
+  Tag: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   classId: PropTypes.string,
   preserveStackingContext: PropTypes.bool,
 }


### PR DESCRIPTION
## Description

Change `Tag` propType to accept strings and functions, so it also accepts components rather than just regular HTML tags.
