### PR TITLE
Replaced the use of StaticQuery in demo with static query hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Since `gatsby-background-image@0.6.0`, this is a monorepo managed by
 
 ## Example Repo
 
-`gatsby-background-image` has an example repository to see it's similarities
+`gatsby-background-image` has an example repository to see its similarities
 & differences to `gatsby-image` side by side.  
 It's located at: [gbitest](https://github.com/timhagn/gbitest)
 To use it with `gatsby-background-image-es5` change the dependency there.

--- a/gbitest/README.md
+++ b/gbitest/README.md
@@ -1,7 +1,7 @@
 # GBI-Test
 
 A quick example repo for [`gatsby-background-image`](https://github.com/timhagn/gatsby-background-image) 
-to demonstrate what it can do and it's similarities & differences to `gatsby-image`.
+to demonstrate what it can do and its similarities & differences to `gatsby-image`.
 
 ## Creation
 
@@ -12,7 +12,7 @@ And last but not least, of course `gatsby-background-image` is part of the crew 
 
 ## Getting Started
 
-Simple clone this repo and run `yarn` or `npm install` to install.
+Simply clone this repo and run `yarn` or `npm install` to install.
 `yarn develop` or `npm run develop` gives you a working [localhost server](http://localhost:8000/).
 
 On the left side you see content wrapped by `<BackgroundImage />` from `gatsby-background-image`,
@@ -33,7 +33,7 @@ the mentioned file as well as at the end of the CSS-file [src/components/layout.
 To read a little more about Contributing to `gatsby-background-image`, see
 the [CONTRIBUTING](https://github.com/timhagn/gatsby-background-image/blob/master/CONTRIBUTING.md) 
 file over there : )!
-If that's TL;DR, just at least read though the passage on [Debugging](https://github.com/timhagn/gatsby-background-image/blob/master/CONTRIBUTING.md#debugging)!
+If that's TL;DR, just at least read through the passage on [Debugging](https://github.com/timhagn/gatsby-background-image/blob/master/CONTRIBUTING.md#debugging)!
 
 ## Scripts
 

--- a/packages/gatsby-background-image-es5/README.md
+++ b/packages/gatsby-background-image-es5/README.md
@@ -73,7 +73,7 @@ _*Of course styleable with `styled-components` and the like!*_
 
 ## Example Repo
 
-`gatsby-background-image` has an example repository to see it's similarities &
+`gatsby-background-image` has an example repository to see its similarities &
 differences to `gatsby-image` side by side.  
 It's located at: [gbitest](https://github.com/timhagn/gbitest)
 To use it with `gatsby-background-image-es5` change the dependency there.
@@ -241,6 +241,55 @@ const BackgroundSection = ({ className }) => {
     </BackgroundImage>
   )
 }
+
+const StyledBackgroundSection = styled(BackgroundSection)`
+  width: 100%;
+  background-position: bottom center;
+  background-repeat: repeat-y;
+  background-size: cover;
+`
+
+export default StyledBackgroundSection
+```
+
+And here is the same component with the data retrieved the old way with the StaticQuery component:
+
+```js
+import React from 'react'
+import { graphql, StaticQuery } from 'gatsby'
+import styled from 'styled-components'
+
+import BackgroundImage from 'gatsby-background-image-es5'
+
+const BackgroundSection = ({ className }) => (
+  <StaticQuery
+    query={graphql`
+      query {
+        desktop: file(relativePath: { eq: "seamless-bg-desktop.jpg" }) {
+          childImageSharp {
+            fluid(quality: 90, maxWidth: 1920) {
+              ...GatsbyImageSharpFluid_withWebp
+            }
+          }
+        }
+      }
+    `}
+    render={data => {
+      // Set ImageData.
+      const imageData = data.desktop.childImageSharp.fluid
+      return (
+        <BackgroundImage
+          Tag="section"
+          className={className}
+          fluid={imageData}
+          backgroundColor={`#040e18`}
+        >
+          <h2>gatsby-background-image-es5</h2>
+        </BackgroundImage>
+      )
+    }}
+  />
+)
 
 const StyledBackgroundSection = styled(BackgroundSection)`
   width: 100%;
@@ -506,7 +555,7 @@ return <StyledBackgound isDarken={isDarken} key={isDarken ? `dark` : `light`} />
 
 As of `gatsby-background-image(-es5)` @ `v0.8.3` the superfluous default of
 `overflow: hidden` was removed, as it was only a remnant from the initial
-creation of `gbi` (see [Acknowledgements](#acknowledgements) for more on it's
+creation of `gbi` (see [Acknowledgements](#acknowledgements) for more on its
 meagre beginnings ; ). As later seen through [issue #59](https://github.com/timhagn/gatsby-background-image/issues/59),
 this might break some CSS styling like `border-radius`, so be sure to include it
 yourself, should you need such styles. Sorry for the inconvenience % )!
@@ -609,7 +658,7 @@ don't count on it in production ; ).
 Starting with `v0.7.5` an extra option is available preserving the
 [CSS stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
 by deactivating the "opacity hack (`opacity: 0.99;`)" used on `<BackgroundImage />`
-to allow it's usage within stacking context changing element styled with e.g.
+to allow its usage within stacking context changing element styled with e.g.
 `grid` or `flex` per default.  
 Activating `preserveStackingContext` prevents this behavior - but allows you to
 use any stacking context changing elements (like elements styled with

--- a/packages/gatsby-background-image-es5/README.md
+++ b/packages/gatsby-background-image-es5/README.md
@@ -207,14 +207,14 @@ This is what a component using `gatsby-background-image-es5` might look like:
 
 ```js
 import React from 'react'
-import { graphql, StaticQuery } from 'gatsby'
+import { graphql, useStaticQuery } from 'gatsby'
 import styled from 'styled-components'
 
 import BackgroundImage from 'gatsby-background-image-es5'
 
-const BackgroundSection = ({ className }) => (
-  <StaticQuery
-    query={graphql`
+const BackgroundSection = ({ className }) => {
+  const data = useStaticQuery(
+    graphql`
       query {
         desktop: file(relativePath: { eq: "seamless-bg-desktop.jpg" }) {
           childImageSharp {
@@ -224,23 +224,23 @@ const BackgroundSection = ({ className }) => (
           }
         }
       }
-    `}
-    render={data => {
-      // Set ImageData.
-      const imageData = data.desktop.childImageSharp.fluid
-      return (
-        <BackgroundImage
-          Tag="section"
-          className={className}
-          fluid={imageData}
-          backgroundColor={`#040e18`}
-        >
-          <h2>gatsby-background-image-es5</h2>
-        </BackgroundImage>
-      )
-    }}
-  />
-)
+    `
+  )
+
+  // Set ImageData.
+  const imageData = data.desktop.childImageSharp.fluid
+
+  return (
+    <BackgroundImage
+      Tag="section"
+      className={className}
+      fluid={imageData}
+      backgroundColor={`#040e18`}
+    >
+      <h2>gatsby-background-image</h2>
+    </BackgroundImage>
+  )
+}
 
 const StyledBackgroundSection = styled(BackgroundSection)`
   width: 100%;

--- a/packages/gatsby-background-image/README.md
+++ b/packages/gatsby-background-image/README.md
@@ -76,7 +76,7 @@ this package.
 
 ## Example Repo
 
-`gatsby-background-image` has an example repository to see it's similarities &
+`gatsby-background-image` has an example repository to see its similarities &
 differences to `gatsby-image` side by side.  
 It's located at: [gbitest](https://github.com/timhagn/gbitest)
 
@@ -259,6 +259,55 @@ const BackgroundSection = ({ className }) => {
     </BackgroundImage>
   )
 }
+
+const StyledBackgroundSection = styled(BackgroundSection)`
+  width: 100%;
+  background-position: bottom center;
+  background-repeat: repeat-y;
+  background-size: cover;
+`
+
+export default StyledBackgroundSection
+```
+
+And here is the same component with the data retrieved the old way with the StaticQuery component:
+
+```js
+import React from 'react'
+import { graphql, StaticQuery } from 'gatsby'
+import styled from 'styled-components'
+
+import BackgroundImage from 'gatsby-background-image'
+
+const BackgroundSection = ({ className }) => (
+  <StaticQuery
+    query={graphql`
+      query {
+        desktop: file(relativePath: { eq: "seamless-bg-desktop.jpg" }) {
+          childImageSharp {
+            fluid(quality: 90, maxWidth: 1920) {
+              ...GatsbyImageSharpFluid_withWebp
+            }
+          }
+        }
+      }
+    `}
+    render={data => {
+      // Set ImageData.
+      const imageData = data.desktop.childImageSharp.fluid
+      return (
+        <BackgroundImage
+          Tag="section"
+          className={className}
+          fluid={imageData}
+          backgroundColor={`#040e18`}
+        >
+          <h2>gatsby-background-image</h2>
+        </BackgroundImage>
+      )
+    }}
+  />
+)
 
 const StyledBackgroundSection = styled(BackgroundSection)`
   width: 100%;
@@ -525,7 +574,7 @@ return <StyledBackgound isDarken={isDarken} key={isDarken ? `dark` : `light`} />
 
 As of `gatsby-background-image(-es5)` @ `v0.8.3` the superfluous default of
 `overflow: hidden` was removed, as it was only a remnant from the initial
-creation of `gbi` (see [Acknowledgements](#acknowledgements) for more on it's
+creation of `gbi` (see [Acknowledgements](#acknowledgements) for more on its
 meagre beginnings ; ). As later seen through [issue #59](https://github.com/timhagn/gatsby-background-image/issues/59),
 this might break some CSS styling like `border-radius`, so be sure to include it
 yourself, should you need such styles. Sorry for the inconvenience % )!
@@ -601,7 +650,7 @@ you use `!important` on its CSS-properties (cause of CSS-specifity).
 Starting with `v0.7.5` an extra option is available preserving the
 [CSS stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
 by deactivating the "opacity hack (`opacity: 0.99;`)" used on `<BackgroundImage />`
-to allow it's usage within stacking context changing element styled with e.g.
+to allow its usage within stacking context changing element styled with e.g.
 `grid` or `flex` per default.  
 Activating `preserveStackingContext` prevents this behavior - but allows you to
 use any stacking context changing elements (like elements styled with

--- a/packages/gatsby-background-image/README.md
+++ b/packages/gatsby-background-image/README.md
@@ -225,14 +225,14 @@ This is what a component using `gatsby-background-image` might look like:
 
 ```js
 import React from 'react'
-import { graphql, StaticQuery } from 'gatsby'
+import { graphql, useStaticQuery } from 'gatsby'
 import styled from 'styled-components'
 
 import BackgroundImage from 'gatsby-background-image'
 
-const BackgroundSection = ({ className }) => (
-  <StaticQuery
-    query={graphql`
+const BackgroundSection = ({ className }) => {
+  const data = useStaticQuery(
+    graphql`
       query {
         desktop: file(relativePath: { eq: "seamless-bg-desktop.jpg" }) {
           childImageSharp {
@@ -242,23 +242,23 @@ const BackgroundSection = ({ className }) => (
           }
         }
       }
-    `}
-    render={data => {
-      // Set ImageData.
-      const imageData = data.desktop.childImageSharp.fluid
-      return (
-        <BackgroundImage
-          Tag="section"
-          className={className}
-          fluid={imageData}
-          backgroundColor={`#040e18`}
-        >
-          <h2>gatsby-background-image</h2>
-        </BackgroundImage>
-      )
-    }}
-  />
-)
+    `
+  )
+
+  // Set ImageData.
+  const imageData = data.desktop.childImageSharp.fluid
+
+  return (
+    <BackgroundImage
+      Tag="section"
+      className={className}
+      fluid={imageData}
+      backgroundColor={`#040e18`}
+    >
+      <h2>gatsby-background-image</h2>
+    </BackgroundImage>
+  )
+}
 
 const StyledBackgroundSection = styled(BackgroundSection)`
   width: 100%;


### PR DESCRIPTION
## Description

The first demo of the plugin in the README file uses the old StaticQuery component instead of a hook. I propose changing this demo to use the static query hook as well as it improves code readability. 

