### PR TITLE
fix: Set correct gatsby peer deps

### DIFF
--- a/packages/gatsby-background-image/package.json
+++ b/packages/gatsby-background-image/package.json
@@ -18,6 +18,7 @@
     "sort-media-queries": "^0.2.2"
   },
   "peerDependencies": {
+    "gatsby": "^2.0.0 || ^3.0.0",
     "react": ">=16.x",
     "react-dom": ">=16.x"
   },

--- a/packages/gbimage-bridge/package.json
+++ b/packages/gbimage-bridge/package.json
@@ -22,6 +22,7 @@
     "microbundle": "^0.13.0"
   },
   "peerDependencies": {
+    "gatsby": "^3.0.0",
     "gatsby-background-image": "^1.4.1",
     "gatsby-plugin-image": "^1.0.1",
     "react": "^16.14.0 || ^17.0.0",


### PR DESCRIPTION
Hello @timhagn, Gatsby maintainer here 👋 
First and foremost, thanks for creating the plugin & maintaining it. Much appreciated!

While looking at your plugin I noticed that the `peerDependency` on `gatsby` is set incorrectly. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

At the moment you say that _any_ version (v3, v4, v5, v6, etc.) will work with this even when in between we'd introduce breaking changes.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

Thanks!
