### PR TITLE
docs: Added GatsbyImage import for BackgroundImage README demo

### DIFF
--- a/packages/gatsby-background-image/README.md
+++ b/packages/gatsby-background-image/README.md
@@ -243,7 +243,7 @@ and usage with `BackgroundImage` is as follows:
 ```jsx
 import React from 'react'
 import { graphql, useStaticQuery } from 'gatsby'
-import { getImage } from "gatsby-plugin-image"
+import { getImage, GatsbyImage } from "gatsby-plugin-image"
 
 import { convertToBgImage } from "gbimage-bridge"
 import BackgroundImage from 'gatsby-background-image'


### PR DESCRIPTION
<!--
  Have any questions? Check out CONTRIBUTING.md or open a question issue : ). 
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
packages/gatsby-background-image/README.md had a missing GatsbyImage import in the [Gatsby 3 & gatsby-plugin-image](https://github.com/timhagn/gatsby-background-image/blob/main/packages/gatsby-background-image/README.md#gatsby-3--gatsby-plugin-image) demo code. Updated the code-block with appropriate imports.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
None
