### PR TITLE
Make IBgImageProps type conform to the attributes that can be received by BgImage

### DIFF
--- a/packages/gbimage-bridge/src/index.tsx
+++ b/packages/gbimage-bridge/src/index.tsx
@@ -6,9 +6,11 @@ import BackgroundImage, {
 import { IGatsbyImageData } from 'gatsby-plugin-image/dist/src/components/gatsby-image.browser';
 import React, { FunctionComponent } from 'react';
 
-type IBaseBgImageProps = Omit<IBackgroundImageProps, 'fluid' | 'fixed'>;
+declare type BackgroundImageProps<T extends IntrinsicTags> = React.Component<InferExtraProps<T> & IBackgroundImageProps>;
+declare type IBaseBgImageProps<T extends IntrinsicTags> = Omit<BackgroundImageProps<T>, 'fluid' | 'fixed'>;
+
 export interface IBgImageProps extends IBaseBgImageProps {
-  image?: IGatsbyImageData;
+  image?: IGatsbyImageData | (string | IGatsbyImageData | undefined)[];
 }
 
 export interface IGatsbyImageDataExtended extends IGatsbyImageData {


### PR DESCRIPTION
## Description
When using this package in a TypeScript project, you cannot add an array of a linear gradient and image to the image property, also you cannot add attributes like styles, className or id to BgImage, nor the Tag attribute

With this change, BgImage uses the same Type the original BackgroundImage uses.