### PR TITLE
docs(readme): describe old-browser support

### DIFF
--- a/packages/gbimage-bridge/README.md
+++ b/packages/gbimage-bridge/README.md
@@ -53,6 +53,20 @@ its [README](https://github.com/timhagn/gatsby-background-image/tree/main/packag
 For installation instructions of `gatsby-plugin-image`, follow the
 aforementioned [migration guide](https://www.gatsbyjs.com/docs/reference/release-notes/image-migration-guide/).
 
+
+## Support for older browsers
+
+If you want to use `gbimage-bridge` with `gatsby-background-image-es5` you have to install all three packages.
+Additionally, make sure you have `core-js` as a dependency in your `package.json`.
+
+```bash
+npm install --save gbimage-bridge gatsby-background-image gatsby-background-es5 core-js`
+```
+
+Add `import core-js/stable` to the component using `gbimage-bridge` and Gatsby will automatically add
+the needed polyfills.
+
+
 ## How to use
 
 For your convenience this package exports a Wrapper around `BackgroundImage`,

--- a/packages/gbimage-bridge/README.md
+++ b/packages/gbimage-bridge/README.md
@@ -60,6 +60,12 @@ If you want to use `gbimage-bridge` with `gatsby-background-image-es5` you have 
 Additionally, make sure you have `core-js` as a dependency in your `package.json`.
 
 ```bash
+yarn add gbimage-bridge gatsby-background-image gatsby-background-es5 core-js`
+```
+
+or 
+
+```bash
 npm install --save gbimage-bridge gatsby-background-image gatsby-background-es5 core-js`
 ```
 


### PR DESCRIPTION
<!--
  Have any questions? Check out CONTRIBUTING.md or open a question issue : ). 
-->

## Description

While using gbimage-bridge on a client's website, I got the feedback that the website crashes on iOS-safari 12. Debugging the issue in a simulator, I found out that the `String.prototype.matchAll`-polyfill was missing (`undefined is not a function`...). Took me a while, to figure out it, the fix was as easy as just importing core-js. So, to spare others the pain, here's a readme-update PR
